### PR TITLE
Scoreboard wither detection

### DIFF
--- a/src/main/java/dev/jeinton/mwutils/util/ScoreboardUtils.java
+++ b/src/main/java/dev/jeinton/mwutils/util/ScoreboardUtils.java
@@ -53,6 +53,14 @@ public class ScoreboardUtils {
         return lines;
     }
 
+    public static List<String> getUnformattedSidebarText(List<String> scores) {
+        List<String> lines = new ArrayList<>(scores);
+        for (int i = 0; i < lines.size(); i++) {
+            lines.set(i, StringUtils.stripControlCodes(lines.get(i)));
+        }
+        return lines;
+    }
+
     public static String getSidebarTitle(Scoreboard scoreboard) {
         ScoreObjective objective = scoreboard.getObjectiveInDisplaySlot(1);
 

--- a/src/main/java/dev/p0ke/fkcounter/FKCounterMod.java
+++ b/src/main/java/dev/p0ke/fkcounter/FKCounterMod.java
@@ -22,7 +22,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class FKCounterMod {
 	
     public static final String MODID = "fkcounter";
-    public static final String VERSION = "2.1";
+    public static final String VERSION = "2.2";
     
     private static FKCounterMod instance;
     


### PR DESCRIPTION
Use scoreboard instead of chat messages to detect if a wither is alive, so missing the wither death message doesn't break the counter.